### PR TITLE
feat: back

### DIFF
--- a/meier/application/blog/presentation/view/post_detail_view.py
+++ b/meier/application/blog/presentation/view/post_detail_view.py
@@ -1,7 +1,10 @@
 from flask import Blueprint, abort, render_template
 from flask import request
 
-from meier.application.admin.base import get_current_user_from_token, UnauthorizedException
+from meier.application.admin.base import (
+    get_current_user_from_token,
+    UnauthorizedException,
+)
 from meier.application.blog.services.opengraph import OpenGraphMetaTagGenerator
 from meier.infrastructure.models.post import Post, PostStatus, PostVisibility
 from meier.infrastructure.models.post_tag import PostTag

--- a/meier/templates/themes/solopreneur/detail_header.html
+++ b/meier/templates/themes/solopreneur/detail_header.html
@@ -1,6 +1,6 @@
 <header>
     <div class="blog-post-back">
-        <a onclick="window.history.back(); return false;">
+        <a href="https://ash84.io">
             <svg fill="#000000" height="35px" width="35px" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg"
                  viewBox="0 0 219.151 219.151" xml:space="preserve">
 <g>


### PR DESCRIPTION
## Summary by Sourcery

Update the back button link in the blog post header to redirect to 'https://ash84.io' instead of using the browser's history back function.